### PR TITLE
Fixes deprecation warning

### DIFF
--- a/gtfsschedule.cabal
+++ b/gtfsschedule.cabal
@@ -73,6 +73,7 @@ library
                      , esqueleto
                      , xdg-basedir
                      , http-conduit
+                     , http-client
                      , conduit
                      , conduit-extra >= 1.1
                      , http-types

--- a/src/CSV/Import.hs
+++ b/src/CSV/Import.hs
@@ -42,8 +42,8 @@ import           Data.Conduit                 (($$+-), newResumableSource)
 import           Data.Conduit.Binary          (sinkFile)
 import           Data.Foldable                (mapM_)
 import           Network.HTTP.Client.Conduit  (defaultManagerSettings)
-import           Network.HTTP.Conduit         (http, newManager, parseUrl,
-                                               responseBody)
+import           Network.HTTP.Client          (parseRequest)
+import           Network.HTTP.Conduit         (http, newManager, responseBody)
 import           Prelude                      hiding (mapM_)
 
 import qualified Codec.Archive.Zip            as Zip
@@ -124,7 +124,7 @@ downloadStaticDataset ::
   -> IO (FilePath)
 downloadStaticDataset url downloadDir = runResourceT $ do
   manager <- liftIO $ newManager defaultManagerSettings
-  request <- liftIO $ parseUrl url
+  request <- liftIO $ parseRequest url
   response <- http request manager
   (newResumableSource $ responseBody response) $$+- sinkFile downloadfp
   return downloadDir


### PR DESCRIPTION
The API has changed and parseRequest is the new function to parse URLs.