### PR TITLE
Fixes http-conduit dependency API changes

### DIFF
--- a/gtfsschedule.cabal
+++ b/gtfsschedule.cabal
@@ -1,5 +1,5 @@
 name:                gtfsschedule
-version:             0.8.0.0
+version:             0.8.1.0
 synopsis:            Be on time for your next public transport service
 description:         Please see README.md
 homepage:            http://github.com/romanofski/gtfsschedule#readme
@@ -72,10 +72,10 @@ library
                      , persistent-template
                      , esqueleto
                      , xdg-basedir
-                     , http-conduit
+                     , http-conduit >= 2.2.0
                      , http-client
-                     , conduit
                      , conduit-extra >= 1.1
+                     , conduit > 1.2
                      , http-types
                      , cassava >= 0.4.5.0
                      , zip-archive

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,7 +13,8 @@ extra-deps:
 - persistent-2.7.3.1
 - persistent-sqlite-2.6.4
 - conduit-extra-1.2.3.2
-- conduit-1.2.13.1
+- conduit-1.2.12.1
+- http-conduit-2.2.4
 - resourcet-1.1.11
 
 # Override default flag values for local packages and extra-deps


### PR DESCRIPTION
I did not realise, that the http-conduit and conduit versions shipped in Fedora
28 and 29 have changed APIs resulting in broken builds.

This patch adjusts the versions as well as the calling functions to fix this.